### PR TITLE
Revert "CustomDelimiter"

### DIFF
--- a/StringCalculatorKata/StringCalculator.cs
+++ b/StringCalculatorKata/StringCalculator.cs
@@ -1,14 +1,10 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace StringCalculatorKata
 {
     public class StringCalculator
     {
-        private static readonly Regex CustomDelimiterRegex = new Regex("(?<=(//)).*");
-        private const string DefaultDelimiter = ",|\n";
-
         public int Add(string sequence)
         {
             if (!sequence.Any())
@@ -19,48 +15,9 @@ namespace StringCalculatorKata
 
         private static string[] ExtractNumberStrings(string sequence)
         {
-            string separator = GetSeparator(sequence);
-            RemoveCustomDelimiterSpecification(ref sequence);
-            return Regex.Split(sequence, separator);
+            return sequence.Split(',','\n');
         }
 
-        private static string GetSeparator(string sequence)
-        {
-            if (HasCustomDelimiter(sequence))
-            {
-                return GetCustomDelimiter(sequence);
-            }
-
-            return DefaultDelimiter;
-        }
-
-        private static bool HasCustomDelimiter(string sequence)
-        {
-            var firstLine = GetFirstLine(sequence);
-
-            return CustomDelimiterRegex.IsMatch(firstLine);
-        }
-        
-        private static string GetCustomDelimiter(string sequence)
-        {
-            var firstLine = GetFirstLine(sequence);
-            return CustomDelimiterRegex.Match(firstLine).Value;
-        }
-        
-        private static string GetFirstLine(string sequence)
-        {
-            return sequence.Split("\n").FirstOrDefault();
-        }
-
-        private static void RemoveCustomDelimiterSpecification(ref string sequence)
-        {
-            if (HasCustomDelimiter(sequence))
-            {
-                var firstLine = GetFirstLine(sequence);
-                sequence = sequence.Remove(0, firstLine.Length + 1);
-            }
-        }
-        
         private static int AddNumbersInAStringSequence(string[] numberStrings)
         {
             int sum = 0;

--- a/StringCalculatorKataTests/StringCalculatorTests.cs
+++ b/StringCalculatorKataTests/StringCalculatorTests.cs
@@ -44,15 +44,6 @@ namespace StringCalculatorKataTests
             int summationResult = _stringCalculator.Add("1\n2,3");
             summationResult.Should().Be(6);
         }
-
-        [Theory]
-        [InlineData("//;\n1;2;3",6)]
-        [InlineData("//separator\n1separator2separator3",6)]
-        public void StringCalculatorAdd_CustomDelimiterSeperatedSequenceString_SequenceSummation(string numberSequence,int result)
-        {
-            int summationResult = _stringCalculator.Add(numberSequence);
-            summationResult.Should().Be(result);
-        }
     }
 
 


### PR DESCRIPTION
Reverts Ibrahim9930/String-Calculator-Kata#4
Found a bug with custom separators that are special regex characters (eg. '|' separator)