### PR TITLE
Fix a bug with custom delimiters in the add method in string calculator

### DIFF
--- a/StringCalculatorKata/StringCalculator.cs
+++ b/StringCalculatorKata/StringCalculator.cs
@@ -44,7 +44,8 @@ namespace StringCalculatorKata
         private static string GetCustomDelimiter(string sequence)
         {
             var firstLine = GetFirstLine(sequence);
-            return CustomDelimiterRegex.Match(firstLine).Value;
+            string customDelimiter = CustomDelimiterRegex.Match(firstLine).Value;
+            return Regex.Escape(customDelimiter);
         }
         
         private static string GetFirstLine(string sequence)

--- a/StringCalculatorKataTests/StringCalculatorTests.cs
+++ b/StringCalculatorKataTests/StringCalculatorTests.cs
@@ -47,6 +47,7 @@ namespace StringCalculatorKataTests
 
         [Theory]
         [InlineData("//;\n1;2;3",6)]
+        [InlineData("//|\n1|2|3",6)]
         [InlineData("//separator\n1separator2separator3",6)]
         public void StringCalculatorAdd_CustomDelimiterSeperatedSequenceString_SequenceSummation(string numberSequence,int result)
         {


### PR DESCRIPTION
The add method can now take a number sequence with special regex characters (eg. '|') as custom delimiters